### PR TITLE
Refactor quantiles module with auto-bin fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
-- No changes yet.
+### Changed
+- Simplified quantile deduplication logic using `dict.fromkeys` instead of iterative reduction.
+- Capped rule-of-thumb bins at n/10 to ensure ~10 observations per bin, fixing issues with heavy-tailed data (e.g., GDP).
+- Fixed `pd.cut` bin assignment to use `right=False` for correct handling of boundary values.
+
+### Added
+- Warning when user-specified `num_bins` is reduced due to non-unique quantiles.
 
 ## 0.2.0 - 2025-12-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Development Commands
+
+```bash
+# Install for development
+uv pip install -e .[dev]
+
+# Run scripts (use uv run instead of python directly)
+uv run python examples/demo.py
+
+# Linting and formatting
+just lint                    # runs ruff format + ruff check --fix
+
+# Type checking
+just ty                      # runs ty check src
+
+# Both lint and type check
+just ok
+```
+
+## Testing
+
+```bash
+# Fast tests (excludes PySpark)
+just ftest
+
+# Full test suite including PySpark
+just test
+
+# Run a single test
+uv run pytest tests/test_binscatter.py::test_name -v
+
+# Run tests for a specific backend
+uv run pytest tests -k "polars"
+```
+
+PySpark tests are skipped by default. Use `--run-pyspark` flag to include them.
+
+## Architecture
+
+### Core Flow
+
+The main `binscatter()` function in `src/binscatter/core.py` orchestrates the entire pipeline:
+
+1. **Input normalization**: Converts any supported dataframe to a narwhals LazyFrame via `clean_df()`
+2. **Quantile computation**: Backend-specific quantile calculation via `configure_quantile_computer()` in `quantiles.py`
+3. **Bin assignment**: Backend-specific bin assignment via `configure_add_bins()` in `quantiles.py`
+4. **Aggregation**: Either simple bin means (`compute_bin_means()`) or control partialing (`partial_out_controls()`)
+5. **Output**: Returns either a Plotly figure or native dataframe
+
+### Backend Strategy Pattern
+
+The codebase uses factory functions that return backend-specific implementations based on `narwhals.Implementation`:
+
+- `configure_quantile_computer()` → Returns a function that computes quantiles for the specific backend
+- `configure_add_bins()` → Returns a function that assigns bin labels for the specific backend
+
+Supported backends: pandas, polars, duckdb, dask, pyspark. Unsupported backends fall back to generic narwhals operations.
+
+### Key Data Structures
+
+- `Profile` (NamedTuple in core.py): Carries configuration through the pipeline (bin count, column names, regression features, etc.)
+- `QuantileCollection` (dataclass in quantiles.py): Holds computed quantile edges and max feasible bins
+
+### Control Partialing
+
+When controls are specified, `partial_out_controls()` implements the Cattaneo et al. (2024) method:
+- Builds normal equations from bin-level aggregates
+- Solves for bin effects and control coefficients jointly
+- Avoids materializing per-row residuals
+
+## Testing Conventions
+
+Tests are parametrized across backends using `@pytest.fixture` from `conftest.py`. The `convert_to_backend()` helper converts pandas DataFrames to each backend type. When adding features, extend parametrized cases in `tests/test_binscatter.py` to cover all backends. Use `numpy.testing` for numeric comparisons across distributed engines.
+
+## Coding Conventions
+
+- Use lazy imports (try/except blocks) for optional backend dependencies—never assume Spark, DuckDB, or Dask availability in core paths
+- Commit style: brief, imperative subjects (e.g., "Add dask support")
+- For Spark work, set `SPARK_LOG_LEVEL=ERROR` to reduce log noise
+
+## Planning
+
+Store the active plan in `PLAN.md`. Keep the current feature plan at the top; archive completed plans below a horizontal rule.

--- a/scripts/readme/make_plots_readme.py
+++ b/scripts/readme/make_plots_readme.py
@@ -1,0 +1,361 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "polars>=1.22.0",
+#     "kaleido>=0.2.1",
+#     "plotly>=6.3",
+#     "numpy>=2.3",
+# ]
+# ///
+"""Generate binscatter demo figures for README and blog posts.
+
+The script expects the canonical README and Optuna artifacts to exist already.
+Spotify, flight, and Pokémon datasets are synthesized when their parquet files
+are absent so we can demo additional narratives without manual downloads.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import plotly.express as px
+import polars as pl
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))  # ensure local binscatter is imported
+
+from binscatter import binscatter  # noqa: E402
+
+ARTIFACTS = ROOT / "artifacts"
+IMAGES = ROOT / "images" / "readme"
+IMAGES.mkdir(parents=True, exist_ok=True)
+RNG = np.random.default_rng(42)
+LOGGER = logging.getLogger("scripts.readme.make_plots")
+if not LOGGER.handlers:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s", "%H:%M:%S")
+    handler.setFormatter(formatter)
+    LOGGER.addHandler(handler)
+LOGGER.setLevel(logging.DEBUG)
+binscatter_logger = logging.getLogger("binscatter.core")
+for handler in LOGGER.handlers:
+    binscatter_logger.addHandler(handler)
+binscatter_logger.setLevel(logging.DEBUG)
+
+
+def _make_binscatter(df: pl.DataFrame, *, x: str, y: str, **kwargs):
+    controls = kwargs.get("controls")
+    other_kwargs = {k: v for k, v in kwargs.items() if k != "controls"}
+    LOGGER.info(
+        "Creating binscatter plot x=%s y=%s controls=%s kwargs=%s",
+        x,
+        y,
+        controls if controls is not None else [],
+        other_kwargs,
+    )
+    fig = binscatter(df, x=x, y=y, **kwargs)
+    LOGGER.info("Finished binscatter plot x=%s y=%s", x, y)
+    return fig
+
+
+def _require_artifact(path: Path) -> Path:
+    if not path.exists():
+        msg = f"Missing {path}. Run the prerequisite prep scripts first."
+        raise FileNotFoundError(msg)
+    return path
+
+
+def _ensure_dataset(path: Path, builder: Callable[[], pl.DataFrame]) -> Path:
+    if not path.exists():
+        df = builder()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        df.write_parquet(path)
+        print(f"Generated synthetic dataset at {path}")  # noqa: T201
+    return path
+
+
+def _write_fig(fig, filename: str, **write_kwargs) -> None:
+    target = IMAGES / filename
+    fig.write_image(str(target), scale=write_kwargs.pop("scale", 2), **write_kwargs)
+    print(f"Wrote {target}")  # noqa: T201
+
+
+def _load_state_df() -> pl.DataFrame:
+    return pl.read_parquet(
+        _require_artifact(ARTIFACTS / "state_data_processed.parquet")
+    ).select(
+        "mtr90_lag3",
+        "lnpat",
+        "top_corp_lag3",
+        "real_gdp_pc",
+        "population_density",
+        "rd_credit_lag3",
+        "statenum",
+        "year",
+    )
+
+
+def _load_optuna_df(name: str, columns: list[str]) -> pl.DataFrame:
+    return pl.read_parquet(
+        _require_artifact(ARTIFACTS / f"optuna_{name}_trials.parquet")
+    ).select(*columns)
+
+
+def _build_spotify_synthetic(rows: int = 1000) -> pl.DataFrame:
+    dance = RNG.beta(2.5, 1.8, size=rows)
+    energy = RNG.beta(2.0, 2.0, size=rows)
+    tempo = RNG.normal(120, 15, size=rows)
+    valence = np.clip(RNG.beta(2.2, 2.0, size=rows), 0, 1)
+    # Inverted-U for popularity: medium valence wins
+    popularity = np.clip(
+        30 + 45 * dance - 80 * (valence - 0.55) ** 2 + RNG.normal(0, 8, size=rows),
+        0,
+        100,
+    )
+    return pl.DataFrame(
+        {
+            "track_id": [f"track_{i}" for i in range(rows)],
+            "danceability": dance,
+            "energy": energy,
+            "tempo": tempo,
+            "popularity": popularity,
+            "valence": valence,
+        }
+    )
+
+
+def _build_flights_synthetic(rows: int = 1500) -> pl.DataFrame:
+    distance = RNG.uniform(150, 2800, size=rows)
+    dep_delay = RNG.normal(5, 25, size=rows)
+    arr_delay = dep_delay * 0.7 + RNG.normal(0, 15, size=rows) + distance / 1500
+    carriers = RNG.choice(["AA", "DL", "UA", "WN", "B6", "AS"], size=rows)
+    return pl.DataFrame(
+        {
+            "flight_id": np.arange(rows),
+            "carrier": carriers,
+            "distance": distance,
+            "dep_delay": dep_delay,
+            "arr_delay": arr_delay,
+        }
+    )
+
+
+def _build_pokemon_synthetic(rows: int = 600) -> pl.DataFrame:
+    tiers = RNG.choice(["Starter", "Rare", "Legendary"], size=rows, p=[0.6, 0.3, 0.1])
+    tier_bonus = {"Starter": 0, "Rare": 30, "Legendary": 80}
+    attack = RNG.normal(70, 20, size=rows) + np.vectorize(tier_bonus.get)(tiers)
+    defense = RNG.normal(65, 18, size=rows) + np.vectorize(tier_bonus.get)(tiers)
+    speed = RNG.normal(70, 22, size=rows) + np.vectorize(tier_bonus.get)(tiers)
+    total = attack + defense + speed + RNG.normal(50, 10, size=rows)
+    return pl.DataFrame(
+        {
+            "name": [f"Pokemon_{i}" for i in range(rows)],
+            "tier": tiers,
+            "attack": attack,
+            "defense": defense,
+            "speed": speed,
+            "total": total,
+        }
+    )
+
+
+def _load_spotify_df() -> pl.DataFrame:
+    path = _ensure_dataset(
+        ARTIFACTS / "spotify_tracks.parquet", _build_spotify_synthetic
+    )
+    return pl.read_parquet(path).select(
+        "danceability",
+        "popularity",
+        "energy",
+        "valence",
+        "tempo",
+    )
+
+
+def _load_flight_df() -> pl.DataFrame:
+    path = _ensure_dataset(
+        ARTIFACTS / "flight_delays.parquet", _build_flights_synthetic
+    )
+    return pl.read_parquet(path).select(
+        "dep_delay",
+        "arr_delay",
+        "distance",
+        "carrier",
+    )
+
+
+def _load_pokemon_df() -> pl.DataFrame:
+    path = _ensure_dataset(
+        ARTIFACTS / "pokemon_stats.parquet", _build_pokemon_synthetic
+    )
+    return pl.read_parquet(path).select(
+        "attack",
+        "defense",
+        "speed",
+        "total",
+    )
+
+
+def build_readme_plot() -> None:
+    df = _load_state_df()
+    controls = [
+        "top_corp_lag3",
+        "real_gdp_pc",
+        "population_density",
+        "rd_credit_lag3",
+        "statenum",
+        "year",
+    ]
+    fig = _make_binscatter(
+        df,
+        x="mtr90_lag3",
+        y="lnpat",
+        controls=controls,
+    )
+    _write_fig(fig, "binscatter_controls.png")
+
+
+def build_elasticnet_plot() -> None:
+    df = _load_optuna_df(
+        "elasticnet",
+        ["alpha", "l1_ratio", "rmse", "duration_seconds"],
+    )
+    fig = _make_binscatter(
+        df,
+        x="alpha",
+        y="rmse",
+        controls=["l1_ratio", "duration_seconds"],
+    )
+    _write_fig(fig, "elasticnet_alpha.png")
+
+
+def build_lightgbm_plot() -> None:
+    df = _load_optuna_df(
+        "lightgbm",
+        [
+            "learning_rate",
+            "num_leaves",
+            "min_child_samples",
+            "feature_fraction",
+            "lambda_l1",
+            "rmse",
+        ],
+    )
+    fig = _make_binscatter(
+        df,
+        x="learning_rate",
+        y="rmse",
+        controls=[
+            "num_leaves",
+            "min_child_samples",
+            "feature_fraction",
+            "lambda_l1",
+        ],
+    )
+    _write_fig(fig, "lightgbm_learning_rate.png")
+
+
+def build_gapminder_plots() -> None:
+    df_pl = pl.from_pandas(px.data.gapminder())
+    fig = _make_binscatter(
+        df_pl,
+        x="gdpPercap",
+        y="lifeExp",
+    )
+    _write_fig(fig, "gapminder_gdp_lifeexp.png")
+
+    df_log = df_pl.select(
+        pl.col("continent"),
+        pl.col("year"),
+        pl.col("lifeExp"),
+        pl.col("gdpPercap"),
+        pl.col("gdpPercap").log().alias("log_gdp"),
+        pl.col("lifeExp").log().alias("log_life"),
+    )
+    fig_log = _make_binscatter(
+        df_log,
+        x="log_gdp",
+        y="log_life",
+    )
+    _write_fig(fig_log, "gapminder_log_axes.png")
+
+
+def build_spotify_plots() -> None:
+    df = _load_spotify_df()
+    fig = _make_binscatter(
+        df,
+        x="danceability",
+        y="popularity",
+        controls=["tempo"],
+    )
+    _write_fig(fig, "spotify_dance_popularity.png")
+
+    fig_energy = _make_binscatter(
+        df,
+        x="energy",
+        y="valence",
+        controls=["tempo"],
+    )
+    _write_fig(fig_energy, "spotify_energy_valence.png")
+
+    fig_valence = _make_binscatter(
+        df,
+        x="valence",
+        y="popularity",
+        controls=["tempo"],
+    )
+    _write_fig(fig_valence, "spotify_valence_popularity.png")
+
+
+def build_flight_plots() -> None:
+    df = _load_flight_df()
+    fig = _make_binscatter(
+        df,
+        x="dep_delay",
+        y="arr_delay",
+        controls=["distance"],
+    )
+    _write_fig(fig, "flight_delay_relationship.png")
+
+    dist_fig = _make_binscatter(
+        df,
+        x="distance",
+        y="arr_delay",
+        controls=["carrier"],
+    )
+    _write_fig(dist_fig, "flight_distance_delay.png")
+
+
+def build_pokemon_plots() -> None:
+    df = _load_pokemon_df()
+    fig = _make_binscatter(
+        df,
+        x="attack",
+        y="defense",
+    )
+    _write_fig(fig, "pokemon_attack_defense.png")
+
+    speed_fig = _make_binscatter(
+        df,
+        x="speed",
+        y="total",
+    )
+    _write_fig(speed_fig, "pokemon_speed_total.png")
+
+
+def main() -> None:
+    build_gapminder_plots()
+    build_readme_plot()
+    build_elasticnet_plot()
+    build_lightgbm_plot()
+    build_spotify_plots()
+    build_flight_plots()
+    build_pokemon_plots()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/binscatter/quantiles.py
+++ b/src/binscatter/quantiles.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import logging
+from typing import Callable, List, Tuple, TYPE_CHECKING, Any, cast
+
+import narwhals as nw
+from narwhals import Implementation
+
+if TYPE_CHECKING:  # pragma: no cover - circular import guard
+    from .core import Profile
+
+logger = logging.getLogger(__name__)
+
+
+def _make_probs(num_bins: int) -> List[float]:
+    if num_bins < 2:
+        raise ValueError("num_bins must be at least 2")
+    return [i / num_bins for i in range(num_bins + 1)]
+
+
+QuantileComputer = Callable[[nw.LazyFrame, str], Tuple[float, ...]]
+
+
+def configure_compute_quantiles(
+    num_bins: int, implementation: Implementation
+) -> QuantileComputer:
+    """Return a function that computes quantile edges for the given backend."""
+    probs = _make_probs(num_bins)
+
+    if implementation == Implementation.PANDAS:
+        return lambda df, x: _quantiles_from_pandas(df, x, probs)
+    if implementation == Implementation.DASK:
+        return lambda df, x: _quantiles_from_dask(df, x, probs)
+    if implementation == Implementation.POLARS:
+        return lambda df, x: _quantiles_from_polars(df, x, probs)
+    if implementation == Implementation.PYSPARK:
+        return lambda df, x: _quantiles_from_pyspark(df, x, probs)
+
+    return lambda df, x: _quantiles_fallback(df, x, probs)
+
+
+def configure_add_bins(
+    profile: "Profile",
+) -> Callable[[nw.LazyFrame, Tuple[float, ...]], nw.LazyFrame]:
+    """Return a function that assigns bin labels given quantiles."""
+    if profile.implementation == Implementation.PANDAS:
+        return lambda df, quantiles: _assign_bins_pandas(df, profile, quantiles)
+    if profile.implementation == Implementation.DASK:
+        return lambda df, quantiles: _assign_bins_dask(df, profile, quantiles)
+    if profile.implementation == Implementation.POLARS:
+        return lambda df, quantiles: _assign_bins_polars(df, profile, quantiles)
+    if profile.implementation == Implementation.PYSPARK:
+        return lambda df, quantiles: _assign_bins_pyspark(df, profile, quantiles)
+    if profile.implementation == Implementation.DUCKDB:
+        return lambda df, quantiles: _assign_bins_duckdb(df, profile, quantiles)
+
+    return lambda df, quantiles: _assign_bins_fallback(df, profile, quantiles)
+
+
+def _quantiles_from_pandas(
+    df: nw.LazyFrame, x_name: str, probs: List[float]
+) -> Tuple[float, ...]:
+    try:
+        df_native = df.to_native()
+        x = df_native[x_name]
+        quantiles = x.quantile(probs)
+    except Exception as err:  # pragma: no cover - dependency optional
+        raise RuntimeError("Pandas quantile computation failed") from err
+    return _to_float_tuple(quantiles)
+
+
+def _quantiles_from_dask(
+    df: nw.LazyFrame, x_name: str, probs: List[float]
+) -> Tuple[float, ...]:
+    try:
+        df_native = df.to_native()
+        quantiles = df_native[x_name].quantile(probs).compute()
+    except Exception as err:  # pragma: no cover - dependency optional
+        raise RuntimeError("Dask quantile computation failed") from err
+    return _to_float_tuple(quantiles)
+
+
+def _quantiles_from_polars(
+    df: nw.LazyFrame, x_name: str, probs: List[float]
+) -> Tuple[float, ...]:
+    try:
+        import polars as pl
+    except ImportError as err:  # pragma: no cover - optional dependency
+        raise ImportError("Polars support requires polars to be installed") from err
+
+    df_native = df.to_native()
+    x_col = pl.col(x_name)
+    exprs = [x_col.quantile(p, interpolation="linear").alias(f"q{p}") for p in probs]
+    qs = df_native.select(exprs).collect()
+    return tuple(float(qs.item(0, i)) for i in range(qs.width))
+
+
+def _quantiles_from_pyspark(
+    df: nw.LazyFrame, x_name: str, probs: List[float]
+) -> Tuple[float, ...]:
+    try:
+        sdf = df.to_native()
+        splits = sdf.approxQuantile(
+            x_name,
+            list(probs),
+            relativeError=0.01,
+        )
+    except Exception as err:  # pragma: no cover - optional dependency
+        raise RuntimeError("PySpark quantile computation failed") from err
+    return tuple(float(v) for v in splits)
+
+
+def _quantiles_fallback(
+    df: nw.LazyFrame, x_name: str, probs: List[float]
+) -> Tuple[float, ...]:
+    x_expr = nw.col(x_name)
+    try:
+        qs = df.select(
+            [x_expr.quantile(p, interpolation="linear").alias(f"q{p}") for p in probs]
+        ).collect()
+    except TypeError:
+        expr = cast(Any, x_expr)
+        qs = df.select([expr.quantile(p).alias(f"q{p}") for p in probs]).collect()
+    except Exception as err:  # pragma: no cover - defensive logging
+        logger.error("Fallback quantile computation failed for df type %s", type(df))
+        raise err
+    qs_nw = qs if hasattr(qs, "to_native") else nw.from_native(qs)
+    num_cols = qs_nw.shape[1]
+    return tuple(float(qs_nw.item(0, i)) for i in range(num_cols))
+
+
+def _assign_bins_pandas(
+    df: nw.LazyFrame, profile: "Profile", quantiles: Tuple[float, ...]
+) -> nw.LazyFrame:
+    try:
+        from pandas import cut
+    except ImportError as err:  # pragma: no cover - optional dependency
+        raise ImportError("Pandas support requires pandas to be installed.") from err
+
+    df_native = df.to_native()
+    # Convert to bin edges: replace first/last with -inf/+inf
+    # Filter out interior values equal to min (they create empty first bin)
+    q_min, q_max = quantiles[0], quantiles[-1]
+    interior = tuple(q for q in quantiles[1:-1] if q != q_min)
+    # If interior is empty but min != max, use max as threshold for 2 bins
+    if not interior and q_min != q_max:
+        interior = (q_max,)
+    edges = (float("-inf"), *interior, float("inf"))
+    num_labels = len(edges) - 1
+    buckets = cut(
+        df_native[profile.x_name],
+        bins=edges,
+        labels=range(num_labels),
+        right=False,
+    )
+    df_native[profile.bin_name] = buckets
+    return nw.from_native(df_native).lazy()
+
+
+def _assign_bins_dask(
+    df: nw.LazyFrame, profile: "Profile", quantiles: Tuple[float, ...]
+) -> nw.LazyFrame:
+    try:
+        from pandas import cut
+    except ImportError as err:  # pragma: no cover
+        raise ImportError("Dask support requires pandas to be installed.") from err
+
+    df_native = df.to_native()
+    # Convert to bin edges: replace first/last with -inf/+inf
+    # Filter out interior values equal to min (they create empty first bin)
+    q_min, q_max = quantiles[0], quantiles[-1]
+    interior = tuple(q for q in quantiles[1:-1] if q != q_min)
+    # If interior is empty but min != max, use max as threshold for 2 bins
+    if not interior and q_min != q_max:
+        interior = (q_max,)
+    edges = (float("-inf"), *interior, float("inf"))
+    labels = range(len(edges) - 1)
+    df_native[profile.bin_name] = df_native[profile.x_name].map_partitions(
+        cut,
+        bins=edges,
+        labels=labels,
+        right=False,
+    )
+    return nw.from_native(df_native).lazy()
+
+
+def _assign_bins_polars(
+    df: nw.LazyFrame, profile: "Profile", quantiles: Tuple[float, ...]
+) -> nw.LazyFrame:
+    try:
+        import polars as pl
+    except ImportError as err:  # pragma: no cover
+        raise ImportError("Polars support requires polars to be installed") from err
+
+    df_native = df.to_native()
+    x_col = pl.col(profile.x_name)
+    # Interior thresholds are quantiles[1:-1], filter out values equal to min
+    q_min, q_max = quantiles[0], quantiles[-1]
+    thresholds = tuple(q for q in quantiles[1:-1] if q != q_min)
+    # If thresholds is empty but min != max, use max as threshold for 2 bins
+    if not thresholds and q_min != q_max:
+        thresholds = (q_max,)
+    if not thresholds:
+        expr = pl.lit(0).alias(profile.bin_name)
+    else:
+        expr = pl.when(x_col.lt(thresholds[0])).then(pl.lit(0))
+        for idx, thr in enumerate(thresholds[1:], start=1):
+            expr = expr.when(x_col.lt(thr)).then(pl.lit(idx))
+        expr = expr.otherwise(pl.lit(len(thresholds))).alias(profile.bin_name)
+    return nw.from_native(df_native.with_columns(expr)).lazy()
+
+
+def _assign_bins_pyspark(
+    df: nw.LazyFrame, profile: "Profile", quantiles: Tuple[float, ...]
+) -> nw.LazyFrame:
+    try:
+        from pyspark.ml.feature import Bucketizer
+        from pyspark.sql.functions import col, lit
+    except ImportError as err:  # pragma: no cover
+        raise ImportError("PySpark support requires pyspark to be installed.") from err
+
+    sdf = df.to_native()
+    # Interior quantiles wrapped with -inf/+inf for Bucketizer
+    # Filter out values equal to min (they create empty first bin)
+    q_min, q_max = quantiles[0], quantiles[-1]
+    interior = tuple(q for q in quantiles[1:-1] if q != q_min)
+    # If interior is empty but min != max, use max as threshold for 2 bins
+    if not interior and q_min != q_max:
+        interior = (q_max,)
+    if not interior:
+        # Single bin case: assign all to bin 0
+        sdf_binned = sdf.withColumn(profile.bin_name, lit(0))
+    else:
+        splits = [float("-inf"), *interior, float("inf")]
+        bucketizer = Bucketizer(
+            splits=splits,
+            inputCol=profile.x_name,
+            outputCol=profile.bin_name,
+            handleInvalid="keep",
+        )
+        sdf_binned = bucketizer.transform(sdf).withColumn(
+            profile.bin_name, col(profile.bin_name).cast("int")
+        )
+    return nw.from_native(sdf_binned).lazy()
+
+
+def _assign_bins_duckdb(
+    df: nw.LazyFrame, profile: "Profile", quantiles: Tuple[float, ...]
+) -> nw.LazyFrame:
+    try:
+        import duckdb  # noqa: F401
+    except ImportError as err:  # pragma: no cover
+        raise ImportError("DuckDB support requires duckdb to be installed.") from err
+
+    rel = df.to_native()
+    # Use CASE WHEN to assign bins based on quantiles
+    # Filter out values equal to min (they create empty first bin)
+    q_min, q_max = quantiles[0], quantiles[-1]
+    thresholds = tuple(q for q in quantiles[1:-1] if q != q_min)
+    # If thresholds is empty but min != max, use max as threshold for 2 bins
+    if not thresholds and q_min != q_max:
+        thresholds = (q_max,)
+    if not thresholds:
+        case_expr = "0"
+    else:
+        parts = []
+        for idx, thr in enumerate(thresholds):
+            parts.append(f"WHEN {profile.x_name} < {thr} THEN {idx}")
+        parts.append(f"ELSE {len(thresholds)}")
+        case_expr = "CASE " + " ".join(parts) + " END"
+
+    rel_with_bins = rel.project(f"*, {case_expr} AS {profile.bin_name}")
+    return nw.from_native(rel_with_bins).lazy()
+
+
+def _assign_bins_fallback(
+    df: nw.LazyFrame, profile: "Profile", quantiles: Tuple[float, ...]
+) -> nw.LazyFrame:
+    # Build quantile bins frame for join_asof
+    # Filter out values equal to min (they create empty first bin)
+    q_min, q_max = quantiles[0], quantiles[-1]
+    interior = tuple(q for q in quantiles[1:-1] if q != q_min)
+    # If interior is empty but min != max, use max as threshold for 2 bins
+    if not interior and q_min != q_max:
+        interior = (q_max,)
+    if not interior:
+        # Single bin case
+        return df.with_columns(nw.lit(0).alias(profile.bin_name))
+
+    quantile_data = {
+        "quantile": list(interior),
+        profile.bin_name: list(range(len(interior))),
+    }
+    quantile_bins = nw.from_dict(quantile_data, backend=df.implementation).lazy()
+
+    return (
+        df.sort(profile.x_name)
+        .join_asof(
+            quantile_bins,
+            left_on=profile.x_name,
+            right_on="quantile",
+            strategy="forward",
+        )
+        .drop("quantile")
+    )
+
+
+def _to_float_tuple(values: Any) -> Tuple[float, ...]:
+    if values is None:
+        return ()
+    if isinstance(values, (list, tuple)):
+        seq = values
+    else:
+        try:
+            seq = list(values)
+        except TypeError:
+            seq = [values]
+    return tuple(float(v) for v in seq)
+
+


### PR DESCRIPTION
## Summary

- **Simplified quantile handling** - replaced iterative reduction with `dict.fromkeys` deduplication
- **Capped rule-of-thumb bins at n/10** - ensures ~10 obs/bin, fixes heavy-tailed data issues (e.g., GDP data was requesting millions of bins)
- **Fixed `pd.cut` with `right=False`** - correct bin assignment at boundaries
- **Added warning** - when user-specified `num_bins` is reduced due to non-unique quantiles
- **Removed dead code** - `compute_max_bins` function and its tests
- **Removed redundant checks** - `num_bins >= 2` in assign_bins functions
- **Updated changelog and readme plots**

## Test plan

- [x] All existing tests pass
- [x] Readme plots regenerated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)