### PR TITLE
Fix LazyFrame schema resolution warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Simplified quantile deduplication logic using `dict.fromkeys` instead of iterative reduction.
 - Capped rule-of-thumb bins at n/10 to ensure ~10 observations per bin, fixing issues with heavy-tailed data (e.g., GDP).
 - Fixed `pd.cut` bin assignment to use `right=False` for correct handling of boundary values.
+- Fixed `PerformanceWarning` when passing Polars LazyFrame by avoiding eager schema resolution.
 
 ### Added
 - Warning when user-specified `num_bins` is reduced due to non-unique quantiles.


### PR DESCRIPTION
## Summary

- Fixed `PerformanceWarning` when passing Polars LazyFrame by detecting lazy frames via `collect_schema` attribute before accessing `.columns`

## Details

When a Polars LazyFrame was passed to `binscatter()`, accessing `.columns` would trigger expensive schema resolution and emit a warning. Now we:

1. Check if input has `collect_schema` attribute (indicates lazy frame)
2. If yes, defer column access to narwhals which handles it properly
3. If no, safely use `.columns` directly (cheap for pandas, polars DataFrame, etc.)

## Test plan

- [x] All tests pass
- [x] No `PerformanceWarning` emitted
- [x] Type checker passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)