### PR TITLE
Backfill CHANGELOG and document the changelog rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,8 +116,27 @@ Update the example notebooks when you:
 - Follow the active Git history style: brief, imperative commit subjects (e.g., "Add dask") with optional detail in the body.
 - Before opening a PR, ensure `make ok` and tests pass locally.
 - Include concise summaries, reference related issues, and add screenshots or HTML links if visual outputs (Plotly renders) changed.
-- Update `CHANGELOG.md` for each feature branch before merging. Add entries under the `## Unreleased` section in the appropriate subsection (`Added`, `Changed`, `Fixed`, etc.).
+- **Update `CHANGELOG.md` in the same commit or PR as the change** (see Changelog section below).
 - **When adding new user-facing features (especially those that change plots), update the example notebooks** (see Example Notebooks section above).
+
+## Changelog
+
+**IMPORTANT: Update `CHANGELOG.md` on every branch, in the same commit or PR as the change itself.**
+
+Add entries under `## Unreleased`, in the appropriate subsection — `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`. Create the subsection if it is not there yet.
+
+This applies to more than library features. Anything a user or contributor would be surprised to discover on their own belongs here:
+
+- New or changed behaviour in `binscatter()` and its helpers
+- Bug fixes, including ones only reachable on a specific backend
+- Build, packaging and release changes (a new publish workflow, dropping a lockfile)
+- Tooling changes that alter what is enforced (a linter upgrade that changes the rules a contributor must satisfy)
+
+Purely internal churn — a refactor with no observable effect, a test-only rename — does not need an entry.
+
+Write entries so they still make sense months later, without the PR open next to them: say what changed and why it matters, not just which symbol moved. Match the level of detail in the existing sections.
+
+Do not defer this to release time. An empty `## Unreleased` section under a series of merged behaviour changes means the history was lost, and reconstructing it from the commit log afterwards is guesswork.
 
 ## Planning
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Added
+- `.github/workflows/publish.yaml`: publishing is driven by GitHub Releases, so cutting a release is the single action that ships a version and pushes to `main` never publish (#72). The release tag is checked against the version in `pyproject.toml` before anything is built, so a release tagged `v0.1.0` cannot ship a `0.4.0` artifact, and upload uses PyPI trusted publishing rather than a stored API token. `workflow_dispatch` runs the same build and `twine check` as a dry run that stops short of publishing.
+
+### Changed
+- Upgraded ruff to 0.16.1 and fixed the 143 findings its newer default rule set reports, rather than staying on a release old enough not to raise them. The version is named in three places that are now kept in step — `ci.yaml`, `.pre-commit-config.yaml`, and `required-version` in `pyproject.toml` — so CI, contributors' hooks and a stray global install cannot lint under different rules; a mismatch fails with one line naming the cause instead of a wall of unreproducible findings. `BLE001` and `S110` are ignored in `pyproject.toml`, since the broad `except` in the optional-backend import guards is the intended behaviour rather than an oversight.
+
+### Removed
+- Stopped committing `uv.lock`; dependency versions are no longer pinned in the repo.
+
+### Fixed
+- `_quantile_edges` (`core.py`, `bin_selectors.py`) no longer carries a `numpy<1.22` fallback passing the `interpolation=` keyword that NumPy removed in 2.0. The project requires `numpy>=2.3`, so the `except TypeError` branch was unreachable and its `type: ignore` was masking a real overload error.
+- The fallback quantile path in `quantiles.py` re-raises with a bare `raise`, preserving the original traceback instead of restarting it at the handler.
+
 ## 0.4.0 - 2026-08-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,25 @@ Update the example notebooks when you:
 3. Test that the entire notebook executes without errors: `uv run jupyter nbconvert --to notebook --execute examples/demo.ipynb --output test_output.ipynb`
 4. Include the notebook updates in the same PR as the feature
 
+## Changelog
+
+**IMPORTANT: Update `CHANGELOG.md` on every branch, in the same commit or PR as the change itself.**
+
+Add entries under `## Unreleased`, in the appropriate subsection — `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`. Create the subsection if it is not there yet.
+
+This applies to more than library features. Anything a user or contributor would be surprised to discover on their own belongs here:
+
+- New or changed behaviour in `binscatter()` and its helpers
+- Bug fixes, including ones only reachable on a specific backend
+- Build, packaging and release changes (a new publish workflow, dropping a lockfile)
+- Tooling changes that alter what is enforced (a linter upgrade that changes the rules a contributor must satisfy)
+
+Purely internal churn — a refactor with no observable effect, a test-only rename — does not need an entry.
+
+Write entries so they still make sense months later, without the PR open next to them: say what changed and why it matters, not just which symbol moved. Match the level of detail in the existing sections.
+
+Do not defer this to release time. An empty `## Unreleased` section under a series of merged behaviour changes means the history was lost, and reconstructing it from the commit log afterwards is guesswork.
+
 ## Planning
 
 Store the active plan in `PLAN.md`. Keep the current feature plan at the top; archive completed plans below a horizontal rule.


### PR DESCRIPTION
Answering "is the changelog up to date?" — it was not.

## What was missing

`## Unreleased` was empty, and `CHANGELOG.md` had not been touched since `3d17e95`. Five merged changes were undocumented:

| change | landed in |
|---|---|
| PyPI publish workflow | #77 |
| ruff 0.9.2 → 0.16.1 upgrade and three-place version pinning | #79 |
| Stopped committing `uv.lock` | `89cf39f` |
| Dead `numpy<1.22` fallback removed from `_quantile_edges` | `073d9e3` |
| Bare `raise` in the `quantiles.py` fallback path | #79 |

All five are now backfilled under `Added` / `Changed` / `Removed` / `Fixed`, written to stand on their own rather than assuming the PR is open alongside.

Two of those were mine, from earlier today, and I did not update the changelog on either.

## Why it was missed

`AGENTS.md` already carried the rule — but as one bullet inside a five-bullet list under Commit & Pull Request Guidelines, between a note about screenshots and a note about notebooks. `CLAUDE.md` had no changelog guidance at all, which is the file an agent working in this repo actually loads.

So this promotes it to its own `## Changelog` section in **both** files, parallel to the existing `## Example Notebooks` section, and leaves a one-line pointer in the PR guidelines.

The new section is explicit that the rule covers more than library features, since that is exactly the category that got skipped here:

- New or changed behaviour in `binscatter()` and its helpers
- Bug fixes, including backend-specific ones
- Build, packaging and release changes (a new publish workflow, dropping a lockfile)
- Tooling changes that alter what is enforced (a linter upgrade that changes the rules a contributor must satisfy)

with purely internal churn explicitly exempt, so the rule does not become noise.

## Verification

`ruff format --check`, `ruff check` and `ty check src` all pass. No source files touched — the diff is `CHANGELOG.md`, `CLAUDE.md` and `AGENTS.md` only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzLtEUXV5KqL1gcMNY7nwe)_