### PR TITLE
Test DPI controls with discrete x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 - `.github/workflows/publish.yaml`: publishing is driven by GitHub Releases, so cutting a release is the single action that ships a version and pushes to `main` never publish (#72). The release tag is checked against the version in `pyproject.toml` before anything is built, so a release tagged `v0.1.0` cannot ship a `0.4.0` artifact, and upload uses PyPI trusted publishing rather than a stored API token. `workflow_dispatch` runs the same build and `twine check` as a dry run that stops short of publishing.
+- Cross-backend regression coverage for the default DPI selector with controls on
+  discrete `x`, ensuring duplicate pilot quantile boundaries produce the two
+  feasible bins and the correct control-adjusted estimates (#70).
 
 ### Changed
 - Upgraded ruff to 0.16.1 and fixed the 143 findings its newer default rule set reports, rather than staying on a release old enough not to raise them. The version is named in three places that are now kept in step — `ci.yaml`, `.pre-commit-config.yaml`, and `required-version` in `pyproject.toml` — so CI, contributors' hooks and a stray global install cannot lint under different rules; a mismatch fails with one line naming the cause instead of a wall of unreproducible findings. `BLE001` and `S110` are ignored in `pyproject.toml`, since the broad `except` in the optional-backend import guards is the intended behaviour rather than an oversight.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,43 @@
 # PLAN.md
 
-## Active Plan: Absorb Fixed Effects (Mundlak) + `categorical=` Parameter
+_No active feature plan._
+
+---
+
+## Archived Plan: Verify Default DPI With Controls on Discrete `x` (#70)
+
+**Status: Complete** — closes #70.
+
+### Outcome note
+
+The reported binary/discrete case already passes on `main`: the DPI helper
+deduplicates the ROT pilot's quantile edges, and the public pipeline caps the result
+to the feasible raw-`x` bins. The regression case deliberately makes the ROT pilot
+request more bins than binary `x` can support, supplies a numeric control, omits
+`num_bins` to exercise the public DPI default, and matches both coordinates against
+an independent least-squares reference on pandas, Polars, DuckDB, Dask, and PySpark.
+
+### Objective
+
+Close the coverage gap around the default automatic selector: when `x` has only a
+few distinct values and controls are supplied, DPI must complete successfully,
+collapse duplicate quantile boundaries to the feasible bin count, and return the
+same finite result on every supported dataframe backend.
+
+### Steps
+
+1. Reproduce the issue with discrete `x`, a numeric control, and the implicit
+   `num_bins="dpi"` default; trace both the DPI pilot and final quantile fallback.
+2. Add a cross-backend regression test that exercises the public default rather
+   than calling the selector helper in isolation.
+3. If the regression test exposes a selector or bin-assignment defect, fix the
+   narrowest shared path and add focused edge-case coverage.
+4. Record the user-visible guarantee in `CHANGELOG.md` and run focused tests,
+   formatting, linting, type checking, and the fast suite.
+
+---
+
+## Archived Plan: Absorb Fixed Effects (Mundlak) + `categorical=` Parameter
 
 **Status: Complete, released as 0.4.0** — closes #69. Multi-way absorption is
 tracked separately in #73.

--- a/tests/test_binscatter.py
+++ b/tests/test_binscatter.py
@@ -561,6 +561,40 @@ def test_dpi_works_across_backends(df_type):
     assert result_pd.shape[0] <= n // 5
 
 
+@pytest.mark.parametrize("df_type", DF_TYPE_PARAMS)
+def test_default_dpi_handles_discrete_x_with_controls(df_type):
+    """The default DPI selector supports controls when x has only two values."""
+    rng = np.random.default_rng(987)
+    x = np.tile([0.0, 1.0], 50)
+    control = rng.normal(size=100)
+    base = pd.DataFrame(
+        {
+            "x0": x,
+            # The steep signal and low noise force the ROT pilot above the two
+            # feasible bins, so DPI has to deduplicate its pilot quantile edges.
+            "y0": 8.0 * x + 1.5 * control + rng.normal(scale=0.05, size=100),
+            "z_ctrl": control,
+        }
+    )
+    assert _get_rot_bins(base, "x0", "y0", controls=["z_ctrl"]) > 2
+    expected_x, expected_y = _manual_binscatter_with_controls(
+        base, 2, control_cols=["z_ctrl"]
+    )
+    native = binscatter(
+        conv(base, df_type),
+        "x0",
+        "y0",
+        controls=["z_ctrl"],
+        return_type="native",
+    )
+    result_pd = to_pandas_native(native).sort_values("bin").reset_index(drop=True)
+
+    assert result_pd.shape[0] == 2
+    assert result_pd["bin"].nunique() == 2
+    np.testing.assert_allclose(result_pd["x0"].to_numpy(), expected_x)
+    np.testing.assert_allclose(result_pd["y0"].to_numpy(), expected_y)
+
+
 def test_dpi_skewed_data():
     """DPI works with skewed distributions."""
     rng = np.random.default_rng(201)


### PR DESCRIPTION
## Summary
- add cross-backend regression coverage for default DPI selection with controls and binary x
- force the ROT pilot above the feasible support and verify DPI deduplicates its pilot quantiles
- compare control-adjusted output against an independent least-squares reference
- update the changelog and archive the completed plan

## Test plan
- focused regression on pandas, Polars, DuckDB, Dask, and PySpark: 5 passed
- Spark-enabled functional suite excluding performance benchmarks: 276 passed, 5 skipped
- fast suite: 241 passed, 53 skipped
- Ruff 0.16.1 and ty: passed

## Notes
The full Spark benchmark run reached an unrelated timing-only failure: the existing 250k-row categorical dummy benchmark took 17.7 seconds against its 10-second threshold.

Closes #70