### PR TITLE
Document vertical confidence intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+- The demo notebook now states that `ci` displays each confidence interval as a
+  vertical bar from its lower to upper bound (#89).
+
 ### Added
 - `.github/pull_request_template.md`, so new pull requests open pre-filled with four headings — What, Why, Verify, Risk — and comments asking for a body under 200 words that describes the change rather than the diff. Unused sections are meant to be deleted rather than marked "N/A".
 - `tests/test_numerical_contract.py`, the portable statement of what #95 is about: the dots are the conditional mean of `y` given the bin at the sample-average controls, and that estimand does not know where a control's origin sits, what units it was measured in, which basis was chosen for the space the controls span, or how many redundant copies of a column were passed in. Each test therefore compares `binscatter()` against the same call on transformed data and needs no oracle. It follows the rules `tests/test_fe_contract.py` follows — only `binscatter()` is imported, nothing is patched, nothing asserts which route ran — so it stays valid across implementations; the multi-factor cases are there because they are the numerically hard ones, not to pin a particular way of handling fixed effects. Coverage spans the dots, the ROT and DPI bin counts, both interval styles, the `poly_line` overlay, degenerate designs, and column names that collide with internal temporaries. Five cases carry `quick` and join `make test-fast`.

--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -232,7 +232,7 @@
    "source": [
     "## 7. Confidence Intervals (`ci`)\n",
     "\n",
-    "`ci` draws an interval around each dot. The two styles answer different questions:\n",
+    "`ci` draws a vertical interval bar from the lower to upper bound of each dot. The two styles answer different questions:\n",
     "\n",
     "- `ci=\"pointwise\"` — the heteroskedasticity-robust interval for the binscatter estimate itself, i.e. how precisely each bin's mean is pinned down. Centred on the dot.\n",
     "- `ci=\"rbc\"` — the robust bias-corrected interval for the *underlying regression function*. The dots are flat within a bin, so they are biased for the true conditional mean; the interval is built from the next-order fit and is deliberately not centred on the dot. This matches `binsreg`'s `ci=(1, 1)`.\n",


### PR DESCRIPTION
Closes #89.

Vertical confidence-interval bars already ship and have plot-output coverage. This PR makes that behavior explicit in the demo notebook.

Verification: make make-nb passed.